### PR TITLE
Fixed typo and removed duplicate listing of compatibility

### DIFF
--- a/src/compatibility.js
+++ b/src/compatibility.js
@@ -113,13 +113,7 @@ function itemTidy5e(item, actorId, callback) {
  */
 export function sheetCompatibilityName(sheetClasses) {
     // List of supported sheets
-    const names = [
-        "tidy5e",
-        "alt5e",
-        "dndbcs",
-        "cb5es",
-        "ogl5e-sheet"
-    ];
+    const names = Object.keys(compatibility).filter(e => e !== "default");
 
     for (let i = 0; i < names.length; i++) {
         if (sheetClasses.includes(names[i])) {
@@ -128,7 +122,7 @@ export function sheetCompatibilityName(sheetClasses) {
     }
 
     // Default Sheet
-    return "defualt";
+    return "default";
 }
 
 export const compatibility = {
@@ -157,7 +151,7 @@ export const compatibility = {
         fetch: fetchOgl5e,
         item: itemDefault
     },
-    "defualt": {
+    "default": {
         currency: currencyDefault,
         fetch: fetchDefault,
         item: itemDefault


### PR DESCRIPTION
For one, the typo `defualt` was corrected to `default`.
Additionally, I found the duplication of compatible system names weird, so I changed that.
Not sure if the `.filter()` is strictly necessary, but I added it, to retain the exact original behavior.